### PR TITLE
fix: reject invalid input (draft section 6)

### DIFF
--- a/lib/base45.js
+++ b/lib/base45.js
@@ -26,9 +26,15 @@ const decode = (input) => {
   for (let i = 0; i < buffer.length; i = i + 3) {
     if (buffer.length - i >= 3) {
       const x = buffer[i] + buffer[i + 1] * 45 + buffer[i + 2] * 45 * 45
+      if (x > 0xFFFF) {
+        throw new Error("Invalid base45 string")
+      }
       res.push(...divmod(x, 256))
     } else {
       const x = buffer[i] + buffer[i + 1] * 45
+      if (x > 0xFF) {
+        throw new Error("Invalid base45 string")
+      }
       res.push(x)
     }
   }


### PR DESCRIPTION
Reject invalid input as recommended in [draft-faltstrom-base45-06 ](https://datatracker.ietf.org/doc/draft-faltstrom-base45/). The following base45 string should be considered invalid

```js
const base45 = require('base45');
base45.decode("NCFOXN%TSMAHN-H/RCMPQ5GE5I00H9GBH3QNAD6.LQLX85ZS GJTSJ4NKP1HCV4*XUA2PSGH.+H$NI4L6F$S-N1FYBRR1$Q1+GOF+P$HQPHQHTQ.SQ6$PUKRN95404.W7UX4795L*KDYPWGO+9AZDOHCRL35IWMSDOP7OQ+M70AK$8 96XY4SBLU96:/6N9R%EPL8RY9DOA60-K.IA.C8KRDL4O54O4IGUJKJGI0JAXD15IAXMFU*GSHGRKMXGG6DBYCBMQN:HG5PAHGG8KES/F-1JW-K%B3A9ENO4B-S-*O4-G1FD/U47HAE1MI4OE0G1:HHD4AB874MM-6B:HKJSQ.TAG3CR1638W9AV88G64PB4VHRY2EK03NFJL4M10KP3AT2VK LT5GGFV85I0*10W2ZXJSBTMFW*+KM2T8-CXR32BMF7RAEAYKMWHE/NH UP4SNGENEWUY97 -3YM0.HAM:D:00ZY35XRT1100MFKWEWYHKCZIZJ0CAQYIKOZIZJ0DAQCDQGAE62ORR7HL0POYQCGMGBBEQFCBCDCT4VYFQZEPYFXK69ZRV9T8IY6NWAYEJF0VXVKNFCG/X9UIG5HFWRPEDW2EPW00S1K83I3900:919FUCKYOUALLGPSUPPORTERS9IKM24N21AW7ZUR2L013300EUISGOEINGDOWNNAZZYFUCKERS666I3AK96XYR01300STOREMYCODEMUTHERFUCKERANDGOTOHELLI5340XRT09SHUZVB33IR0IPUTAVIRUSHERE83H73KFI280I23KL0YRZT91Y0WITHLOVEFROMHA1*PWEOXCI/QXRLOZKN0LM*03I2RWT0Z");
```